### PR TITLE
Added Mini SAM Boards

### DIFF
--- a/mu/modes/circuitpython.py
+++ b/mu/modes/circuitpython.py
@@ -46,6 +46,8 @@ class CircuitPythonMode(MicroPythonMode):
         (0x1209, 0xBAB3),  # Electronic Cats Bast Pro Mini M0
         (0x1B4F, 0x8D22),  # SparkFun SAMD21 Mini Breakout
         (0x1B4F, 0x8D23),  # SparkFun SAMD21 Dev Breakout
+        (0x1209, 0x2017),  # Mini SAM M4
+        (0x1209, 0x7102),  # Mini SAM M0
     ]
     # Modules built into CircuitPython which mustn't be used as file names
     # for source code.


### PR DESCRIPTION
Added Mini SAM Mx boards with VID 1209 and PIDs, 2017 (Mini SAM M4) and 7102 (Mini SAM M0) to the list of valid boards.